### PR TITLE
Add Practice Test Flow with Dynamic WPG Integration

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,9 @@ import Header from "@/components/Header";
 import Index from "./pages/Index";
 import StemTutorPage from "./pages/StemTutorPage";
 import NotFound from "./pages/NotFound";
+import PracticeTestPage from "./pages/PracticeTestPage";
+import TestPage from './pages/TestPage';
+
 
 type UserInfo = {
   name: string;
@@ -29,6 +32,8 @@ const AppRoutes: React.FC<{
     <Routes>
       <Route path="/" element={<Index user={user} onLogout={onLogout} refreshUser={refreshUser} />} />
       <Route path="/tutor" element={<StemTutorPage user={user} onLogout={onLogout} refreshUser={refreshUser} />} />
+      <Route path="/practice" element={<PracticeTestPage />} />
+      <Route path="/test" element={<TestPage />} />
       {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
       <Route path="*" element={<NotFound />} />
     </Routes>

--- a/src/components/StemTutor.tsx
+++ b/src/components/StemTutor.tsx
@@ -109,12 +109,14 @@ const StemTutor: React.FC<StemTutorProps> = ({ user }) => {
                 {
                   title: "Practice Tests",
                   description: "Prepare for exams with targeted practice",
-                  icon: "📋"
+                  icon: "📋",
+                  onClick: () => navigate('/practice')
                 }
               ].map((feature, index) => (
                 <div
                   key={index}
-                  className="rounded-lg p-6 shadow-md transition-all duration-300 hover:shadow-lg hover:scale-105 hover:-translate-y-1 animate-fade-in"
+                  onClick={feature.onClick}
+                  className={`rounded-lg p-6 shadow-md transition-all duration-300 hover:shadow-lg hover:scale-105 hover:-translate-y-1 animate-fade-in ${feature.onClick ? 'cursor-pointer' : ''}`}
                   style={{
                     backgroundColor: 'var(--theme-card-bg)',
                     borderColor: 'var(--theme-border)',

--- a/src/pages/PracticeTestPage.tsx
+++ b/src/pages/PracticeTestPage.tsx
@@ -1,0 +1,100 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+
+type WPGData = Record<string, string[]>;
+
+const PracticeTestPage: React.FC = () => {
+  const [topics, setTopics] = useState<WPGData>({});
+  const [expandedTopic, setExpandedTopic] = useState<string | null>(null);
+  const [selectedSubjects, setSelectedSubjects] = useState<Set<string>>(new Set());
+  const [difficulty, setDifficulty] = useState('Beginner');
+
+  useEffect(() => {
+    axios.get('http://localhost:5000/wpg/topics')
+      .then((res) => setTopics(res.data))
+      .catch((err) => console.error('Failed to fetch WPG topics:', err));
+  }, []);
+
+  const toggleSubject = (subject: string) => {
+    setSelectedSubjects((prev) => {
+      const updated = new Set(prev);
+      if (updated.has(subject)) {
+        updated.delete(subject);
+      } else {
+        updated.add(subject);
+      }
+      return updated;
+    });
+  };
+
+  return (
+    <div className="min-h-screen bg-white text-black p-6">
+      <h1 className="text-3xl font-bold mb-4">🧪 Practice Test Setup</h1>
+
+      <label className="block mb-4">
+        <span className="text-lg font-semibold">Select Difficulty:</span>
+        <select
+          className="mt-1 block w-60 border p-2 rounded"
+          value={difficulty}
+          onChange={(e) => setDifficulty(e.target.value)}
+        >
+          <option>Beginner</option>
+          <option>Intermediate</option>
+          <option>Advanced</option>
+        </select>
+      </label>
+
+      <h2 className="text-2xl font-bold mb-2">Topics</h2>
+
+      <div className="space-y-4">
+        {Object.entries(topics).map(([topic, subjects]) => (
+          <div key={topic} className="border rounded p-4 shadow-md">
+            <div
+              className="cursor-pointer font-semibold text-lg flex justify-between items-center"
+              onClick={() => setExpandedTopic(expandedTopic === topic ? null : topic)}
+            >
+              <span>{topic} ({subjects.length})</span>
+              <span>{expandedTopic === topic ? '▲' : '▼'}</span>
+            </div>
+
+            {expandedTopic === topic && (
+              <div className="mt-3 ml-4 grid grid-cols-2 gap-2">
+                {subjects.map((sub) => (
+                  <label key={sub} className="flex items-center gap-2">
+                    <input
+                      type="checkbox"
+                      checked={selectedSubjects.has(sub)}
+                      onChange={() => toggleSubject(sub)}
+                    />
+                    <span>{sub}</span>
+                  </label>
+                ))}
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+
+      {/* ✅ Generate Test Button */}
+      <div className="mt-8 text-center">
+        <button
+          disabled={selectedSubjects.size === 0}
+          onClick={() => {
+            localStorage.setItem('selectedSubjects', JSON.stringify(Array.from(selectedSubjects)));
+            localStorage.setItem('difficulty', difficulty);
+            window.location.href = "/test";
+          }}
+          className={`px-6 py-3 rounded font-semibold transition ${
+            selectedSubjects.size === 0
+              ? "bg-gray-300 text-gray-500 cursor-not-allowed"
+              : "bg-blue-600 text-white hover:bg-blue-700"
+          }`}
+        >
+          Generate Test
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default PracticeTestPage;

--- a/src/pages/TestPage.tsx
+++ b/src/pages/TestPage.tsx
@@ -1,0 +1,92 @@
+// src/pages/TestPage.tsx
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+
+interface Question {
+  wpg_topic: string;
+  wpg_difficulty: string;
+  wpg_instance_steps_command: string;
+  wpg_instance_answers: { MathematicaSolution: string[] }[];
+}
+
+const TestPage: React.FC = () => {
+  const [questions, setQuestions] = useState<Question[]>([]);
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [userAnswers, setUserAnswers] = useState<string[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const selectedSubjects = JSON.parse(localStorage.getItem('selectedSubjects') || '[]');
+    const difficulty = localStorage.getItem('difficulty') || 'Beginner';
+
+    if (!selectedSubjects.length) return;
+
+    const payload = {
+      wpg_input: selectedSubjects.slice(0, 1).map((subject: string) => ({
+        wpg_topic: subject,
+        wpg_instances: 10,
+        wpg_difficulty: difficulty,
+        wpg_answer_type: 'Single Expression'
+      }))
+    };
+
+    axios.post('http://localhost:5000/wpg/questions', payload)
+      .then(res => {
+        setQuestions(res.data);
+        setUserAnswers(new Array(res.data.length).fill(''));
+        setLoading(false);
+      })
+      .catch(err => {
+        console.error('Failed to fetch questions', err);
+        setLoading(false);
+      });
+  }, []);
+
+  const handleAnswerChange = (value: string) => {
+    const updated = [...userAnswers];
+    updated[currentIndex] = value;
+    setUserAnswers(updated);
+  };
+
+  if (loading) return <div className="p-6">Loading questions...</div>;
+  if (!questions.length) return <div className="p-6">No questions available.</div>;
+
+  const q = questions[currentIndex];
+
+  return (
+    <div className="min-h-screen p-6">
+      <h1 className="text-2xl font-bold mb-4">Question {currentIndex + 1} of {questions.length}</h1>
+
+      <div className="mb-4 p-4 border rounded bg-gray-50">
+        <strong>Command:</strong> <code>{q.wpg_instance_steps_command}</code>
+      </div>
+
+      <input
+        className="w-full p-2 border rounded mb-4"
+        placeholder="Enter your answer here..."
+        value={userAnswers[currentIndex] || ''}
+        onChange={(e) => handleAnswerChange(e.target.value)}
+      />
+
+      <div className="flex justify-between">
+        <button
+          className="px-4 py-2 rounded bg-gray-300 hover:bg-gray-400"
+          onClick={() => setCurrentIndex(i => Math.max(0, i - 1))}
+          disabled={currentIndex === 0}
+        >
+          ⬅️ Previous
+        </button>
+
+        <button
+          className="px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700"
+          onClick={() => setCurrentIndex(i => Math.min(questions.length - 1, i + 1))}
+          disabled={currentIndex === questions.length - 1}
+        >
+          Next ➡️
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default TestPage;


### PR DESCRIPTION
### Overview
This PR introduces the initial flow for dynamic practice test generation using the Wolfram Problem Generator (WPG).

### Key Features
- Adds `/practice` page for selecting WPG topics and subtopics (fetched from backend)
- Supports multi-selection of subjects and difficulty level
- Enables a "Generate Test" button once at least one subject is selected
- Navigates to `/test` page with selected config
- Fetches 10 questions dynamically using WPG backend
- Displays one question at a time with navigation and answer input field

### Backend
- Adds `/wpg/topics` and `/wpg/questions` Flask routes to securely proxy WPG API requests
- Includes logging and error handling for WPG access token failures and quota limits

### Notes
- WPG quota error is currently being handled; mock data may be used during subscription downtime.
- Future steps: result submission, scoring, and review summary page.
